### PR TITLE
Save fuel, cargo fuel and damage of the vehicles

### DIFF
--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -145,7 +145,7 @@ private ["_fobPos", "_fobObjects", "_grpUnits", "_fobMines"];
 } forEach KPLIB_sectors_fob;
 
 // Save all fetched objects
-private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inventory"];
+private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inventory", "_fuel"];
 {
     // Position data
     _savedPos = getPosWorld _x;
@@ -154,6 +154,7 @@ private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inv
     _class = typeOf _x;
     _hasCrew = false;
 	_inventory = [];
+	_fuel = 
 
     // Determine if vehicle is crewed
     if ((toLowerANSI _class) in KPLIB_b_allVeh_classes) then {
@@ -171,8 +172,10 @@ private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inv
         // Serialize inventory
         _inventory = [_x] call fnc_serializeCargo;
 
-        _objectsToSave pushBack [_class, _savedPos, _savedVecDir, _savedVecUp, _hasCrew, _inventory];
+        _objectsToSave pushBack [_class, _savedPos, _savedVecDir, _savedVecUp, _hasCrew, _inventory, _fuel];
     };
+	
+	
 } forEach _allObjects;
 
 // Save all storages and resources

--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -145,7 +145,7 @@ private ["_fobPos", "_fobObjects", "_grpUnits", "_fobMines"];
 } forEach KPLIB_sectors_fob;
 
 // Save all fetched objects
-private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inventory", "_fuel"];
+private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inventory", "_fuel", "_fuelCargo", "_damages"];
 {
     // Position data
     _savedPos = getPosWorld _x;
@@ -154,7 +154,6 @@ private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inv
     _class = typeOf _x;
     _hasCrew = false;
 	_inventory = [];
-	_fuel = 
 
     // Determine if vehicle is crewed
     if ((toLowerANSI _class) in KPLIB_b_allVeh_classes) then {
@@ -171,8 +170,12 @@ private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inv
         
         // Serialize inventory
         _inventory = [_x] call fnc_serializeCargo;
-
-        _objectsToSave pushBack [_class, _savedPos, _savedVecDir, _savedVecUp, _hasCrew, _inventory, _fuel];
+        
+        _fuel = fuel _x;
+        _fuelCargo = getFuelCargo _x;
+        _damages = getAllHitPointsDamage _x;
+        
+        _objectsToSave pushBack [_class, _savedPos, _savedVecDir, _savedVecUp, _hasCrew, _inventory, _fuel, _fuelCargo, _damages];
     };
 	
 	

--- a/Missionframework/functions/fn_getSaveData.sqf
+++ b/Missionframework/functions/fn_getSaveData.sqf
@@ -172,7 +172,7 @@ private ["_savedPos", "_savedVecDir", "_savedVecUp", "_class", "_hasCrew", "_inv
         _inventory = [_x] call fnc_serializeCargo;
         
         _fuel = fuel _x;
-        _fuelCargo = getFuelCargo _x;
+        _fuelCargo = _x call ace_refuel_fnc_getFuel;
         _damages = getAllHitPointsDamage _x;
         
         _objectsToSave pushBack [_class, _savedPos, _savedVecDir, _savedVecUp, _hasCrew, _inventory, _fuel, _fuelCargo, _damages];

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -437,6 +437,9 @@ if (!isNil "_saveData") then {
             // Reposition spawned object
             _object setPosWorld _pos;
             _object setVectorDirAndUp [_vecDir, _vecUp];
+			
+			// Persistent fuel
+			_object setFuel _fuel;
 
             // Process KP object init
             [_object] call KPLIB_fnc_addObjectInit;
@@ -468,6 +471,7 @@ if (!isNil "_saveData") then {
             if ((count _inventory) == 4) then {
                 [_object, _inventory] call fnc_loadCustomCargo;
             };
+			
         };
     } forEach _objectsToSave;
 


### PR DESCRIPTION
All saveable vehicles (objects tbh) will have fuel, ACE refuel state and AllHitPoints damage saved and then loaded back in.

Ammo is ignored for now - that's more annoying to deal with.

closes #4 