### PR TITLE
Fix RPT error in vehicle save manager

### DIFF
--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -445,7 +445,7 @@ if (!isNil "_saveData") then {
             // Persistent damage
             if (!isNil "_damages") then
             {
-                __cnt = count (_damages select 0);
+                private __cnt = count (_damages select 0);
                 if (__cnt > 0) then
                 {
                     _object allowdamage true; // dmg enabled otherwise seHitPointDamage won't do anything

--- a/Missionframework/scripts/server/game/save_manager.sqf
+++ b/Missionframework/scripts/server/game/save_manager.sqf
@@ -445,12 +445,13 @@ if (!isNil "_saveData") then {
             // Persistent damage
             if (!isNil "_damages") then
             {
-                private __cnt = count (_damages select 0);
-                if (__cnt > 0) then
+                private _cnt = count (_damages select 0);
+                if(isNil "_cnt") then { _cnt = 0; };
+                if (_cnt > 0) then
                 {
                     _object allowdamage true; // dmg enabled otherwise seHitPointDamage won't do anything
                     
-                    for "__i" from 0 to __cnt - 1 do
+                    for "__i" from 0 to _cnt - 1 do
                     {
                         __part = (_damages select 0) select __i;
                         __hp = (_damages select 2) select __i;


### PR DESCRIPTION
Fix (probably) error in RPT files:
12:51:55   Error position: <__cnt > 0) then
{
_object allowdamage tr>
12:51:55   Error Undefined variable in expression: __cnt