### PR TITLE
Feature/msp nato names

### DIFF
--- a/Missionframework/CfgFunctions.hpp
+++ b/Missionframework/CfgFunctions.hpp
@@ -41,6 +41,7 @@ class KPLIB {
         class getLocationName           {};
         class getMilitaryId             {};
         class getMobileRespawns         {};
+        class getMobileRespawnName      {};
         class getNearbyPlayers          {};
         class getNearestBluforObjective {};
         class getNearestFob             {};

--- a/Missionframework/functions/fn_getMobileRespawnName.sqf
+++ b/Missionframework/functions/fn_getMobileRespawnName.sqf
@@ -24,7 +24,7 @@ private _respawn_vehicles = [] call KPLIB_fnc_getMobileRespawns;
 private _name = "VEHICLE_NOT_FOUND";
 
 if (!isNil "_msp") then {
-    private _vehicle_idx = _respawn_vehicles findIf _msp;
+    private _vehicle_idx = _respawn_vehicles find _msp;
     if (_vehicle_idx != -1 && _vehicle_idx < count KPLIB_militaryAlphabet) then {
         _name = KPLIB_militaryAlphabet select _vehicle_idx;
     };

--- a/Missionframework/functions/fn_getMobileRespawnName.sqf
+++ b/Missionframework/functions/fn_getMobileRespawnName.sqf
@@ -1,0 +1,31 @@
+/*
+    File: fn_getMobileRespawnName.sqf
+    Author: doxus
+    Date: 2024-04-23
+    Last Update: 2024-04-23
+    License: MIT License - http://www.opensource.org/licenses/MIT
+
+    Description:
+        Gets NATO military name of the given respawn vehicle (assigned per idx)
+
+    Parameter(s):
+        _msp - mobile respawn vehicle object reference (defaults to nil)
+
+    Returns:
+        Mobile respawn name
+*/
+
+
+params [
+    ["_msp", nil]
+];
+
+private _respawn_vehicles = [] call KPLIB_fnc_getMobileRespawns;
+private _vehicle_idx = _respawn_vehicles findIf _msp;
+private _name = "VEHICLE_NOT_FUND";
+
+if (_vehicle_idx != -1 && _vehicle_idx < count KPLIB_militaryAlphabet) then {
+    _name = KPLIB_militaryAlphabet select _vehicle_idx;
+};
+
+_name

--- a/Missionframework/functions/fn_getMobileRespawnName.sqf
+++ b/Missionframework/functions/fn_getMobileRespawnName.sqf
@@ -21,11 +21,12 @@ params [
 ];
 
 private _respawn_vehicles = [] call KPLIB_fnc_getMobileRespawns;
-private _vehicle_idx = _respawn_vehicles findIf _msp;
-private _name = "VEHICLE_NOT_FUND";
+private _name = "VEHICLE_NOT_FOUND";
 
-if (_vehicle_idx != -1 && _vehicle_idx < count KPLIB_militaryAlphabet) then {
-    _name = KPLIB_militaryAlphabet select _vehicle_idx;
+if (!isNil "_msp") then {
+    private _vehicle_idx = _respawn_vehicles findIf _msp;
+    if (_vehicle_idx != -1 && _vehicle_idx < count KPLIB_militaryAlphabet) then {
+        _name = KPLIB_militaryAlphabet select _vehicle_idx;
+    };
 };
-
 _name

--- a/Missionframework/scripts/client/markers/fob_markers.sqf
+++ b/Missionframework/scripts/client/markers/fob_markers.sqf
@@ -41,7 +41,7 @@ while {true} do {
         if (count _respawn_trucks == count _markers_mobilespawns) then {
             for "_idx" from 0 to ((count _markers_mobilespawns) - 1) do {
                 (_markers_mobilespawns select _idx) setMarkerPosLocal getPos (_respawn_trucks select _idx);
-                (_markers_mobilespawns select _idx) setMarkerTextLocal format ["%1 %2", localize "STR_RESPAWN_TRUCK", [_idx] call KPLIB_fnc_getMobileRespawnName];
+                (_markers_mobilespawns select _idx) setMarkerTextLocal format ["%1 %2", localize "STR_RESPAWN_TRUCK", [_respawn_trucks select _idx] call KPLIB_fnc_getMobileRespawnName];
             };
         };
     };

--- a/Missionframework/scripts/client/markers/fob_markers.sqf
+++ b/Missionframework/scripts/client/markers/fob_markers.sqf
@@ -41,7 +41,7 @@ while {true} do {
         if (count _respawn_trucks == count _markers_mobilespawns) then {
             for "_idx" from 0 to ((count _markers_mobilespawns) - 1) do {
                 (_markers_mobilespawns select _idx) setMarkerPosLocal getPos (_respawn_trucks select _idx);
-                (_markers_mobilespawns select _idx) setMarkerTextLocal format ["%1 %2", localize "STR_RESPAWN_TRUCK", mapGridPosition (_respawn_trucks select _idx)];
+                (_markers_mobilespawns select _idx) setMarkerTextLocal format ["%1 %2", localize "STR_RESPAWN_TRUCK", [_idx] call KPLIB_fnc_getMobileRespawnName];
             };
         };
     };

--- a/Missionframework/scripts/client/spawn/redeploy_manager.sqf
+++ b/Missionframework/scripts/client/spawn/redeploy_manager.sqf
@@ -103,9 +103,8 @@ while {true} do {
                 private _respawn_trucks = [] call KPLIB_fnc_getMobileRespawns;
 
                 {
-                    _name = [_x] call KPLIB_fnc_getMobileRespawnName;
                     KPLIB_respawnPositionsList pushBack [
-                       format ["%1 - %2", localize "STR_RESPAWN_TRUCK",  _name)],
+                       format ["%1 - %2", localize "STR_RESPAWN_TRUCK",  [_x] call KPLIB_fnc_getMobileRespawnName],
                         getPosATL _x,
                         _x
                     ];

--- a/Missionframework/scripts/client/spawn/redeploy_manager.sqf
+++ b/Missionframework/scripts/client/spawn/redeploy_manager.sqf
@@ -103,7 +103,7 @@ while {true} do {
                 private _respawn_trucks = [] call KPLIB_fnc_getMobileRespawns;
 
                 {
-                    _name = [_x] KPLIB_fnc_getMobileRespawnName;
+                    _name = [_x] call KPLIB_fnc_getMobileRespawnName;
                     KPLIB_respawnPositionsList pushBack [
                        format ["%1 - %2", localize "STR_RESPAWN_TRUCK",  _name)],
                         getPosATL _x,

--- a/Missionframework/scripts/client/spawn/redeploy_manager.sqf
+++ b/Missionframework/scripts/client/spawn/redeploy_manager.sqf
@@ -103,8 +103,9 @@ while {true} do {
                 private _respawn_trucks = [] call KPLIB_fnc_getMobileRespawns;
 
                 {
+                    _name = [_x] KPLIB_fnc_getMobileRespawnName;
                     KPLIB_respawnPositionsList pushBack [
-                        format ["%1 - %2", localize "STR_RESPAWN_TRUCK", mapGridPosition getPosATL _x],
+                       format ["%1 - %2", localize "STR_RESPAWN_TRUCK",  _name)],
                         getPosATL _x,
                         _x
                     ];


### PR DESCRIPTION
Change mobile respawn names to use NATO military alphabet instead of grid refrence.

New function  KPLIB_fnc_getMobileRespawnName returns name based on index in array returned by KPLIB_fnc_getMobileRespawns.

If the passed vehicle is not found (or is out of bounds for NATO alphabet) "VEHICLE_NOT_FOUND" string will be returned.

Names are changed both on the map and redeploy manager