### PR TITLE
Lower min and max spawn ranges for opfor

### DIFF
--- a/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
+++ b/Missionframework/scripts/server/battlegroup/spawn_battlegroup.sqf
@@ -6,7 +6,7 @@ params [
 
 if (KPLIB_endgame == 1) exitWith {};
 
-_spawn_marker = [[2000, 1000] select _infOnly, 3000, false, markerPos _spawn_marker] call KPLIB_fnc_getOpforSpawnPoint;
+_spawn_marker = [[800, 600] select _infOnly, [1600, 1000] select _infOnly, false, markerPos _spawn_marker] call KPLIB_fnc_getOpforSpawnPoint;
 
 if !(_spawn_marker isEqualTo "") then {
     KPLIB_last_battlegroup_time = diag_tickTime;

--- a/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
+++ b/Missionframework/scripts/server/patrols/manage_one_patrol.sqf
@@ -18,7 +18,7 @@ while { KPLIB_endgame == 0 } do {
 
     _spawn_marker = "";
     while { _spawn_marker == "" } do {
-        _spawn_marker = [2000,5000,true] call KPLIB_fnc_getOpforSpawnPoint;
+        _spawn_marker = [1500,4000,true] call KPLIB_fnc_getOpforSpawnPoint;
         if ( _spawn_marker == "" ) then {
             sleep (150 + (random 150));
         };


### PR DESCRIPTION
Lowered min and max ranges used when searching for viable patrol and battlegroup spawnpoint:
| Type | previous range | current range |
| --- | --- | --- |
| Battlegroup (infantry) | 1000m - 3000m | 600m - 1000m |
| Battlegroup (w/ vehicles) | 2000m - 3000m | 800m - 1600m |
| Patrol | 2000m - 5000m | 1500m - 4000m |