### PR TITLE
Change MSP naming convention

### DIFF
--- a/Missionframework/functions/fn_getMobileRespawnName.sqf
+++ b/Missionframework/functions/fn_getMobileRespawnName.sqf
@@ -26,7 +26,7 @@ private _name = "VEHICLE_NOT_FOUND";
 if (!isNil "_msp") then {
     private _msp_name = _msp getVariable ["msp_name", nil];
 
-    if (_msp_name != nil) then {
+    if (!isNil "_msp_name") then {
         _name = _msp_name;
     }
     else {

--- a/Missionframework/functions/fn_getMobileRespawnName.sqf
+++ b/Missionframework/functions/fn_getMobileRespawnName.sqf
@@ -33,7 +33,7 @@ if (!isNil "_msp") then {
         //get random name from the russian alphabet
         _name = selectRandom KPLIB_russianAlphabet + " ";
         //add random number (3 digits)
-        _name = _name + format ["%1%2%3", random 9, random 9, random 9];
+        _name = _name + format ["%1%2%3", floor random 9, floor random 9, floor random 9];
         _msp setVariable ["msp_name", _name];
         //use msp_name
     };

--- a/Missionframework/functions/fn_getMobileRespawnName.sqf
+++ b/Missionframework/functions/fn_getMobileRespawnName.sqf
@@ -24,9 +24,18 @@ private _respawn_vehicles = [] call KPLIB_fnc_getMobileRespawns;
 private _name = "VEHICLE_NOT_FOUND";
 
 if (!isNil "_msp") then {
-    private _vehicle_idx = _respawn_vehicles find _msp;
-    if (_vehicle_idx != -1 && _vehicle_idx < count KPLIB_militaryAlphabet) then {
-        _name = KPLIB_militaryAlphabet select _vehicle_idx;
+    private _msp_name = _msp getVariable ["msp_name", nil];
+
+    if (_msp_name != nil) then {
+        _name = _msp_name;
+    }
+    else {
+        //get random name from the russian alphabet
+        _name = selectRandom KPLIB_russianAlphabet + " ";
+        //add random number (3 digits)
+        _name = _name + format ["%1%2%3", random 9, random 9, random 9];
+        _msp setVariable ["msp_name", _name];
+        //use msp_name
     };
 };
 _name

--- a/Missionframework/presets/init_presets.sqf
+++ b/Missionframework/presets/init_presets.sqf
@@ -271,6 +271,8 @@ KPLIB_typeAirClasses   = +KPLIB_b_air_classes;
 
 // Military alphabet used for FOBs and convoys
 KPLIB_militaryAlphabet = ["Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel", "India", "Juliet", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-Ray", "Yankee", "Zulu"];
+// Russian military alphabet used for MSP naming
+KPLIB_russianAlphabet = ["Anna", "Boris", "Vasily", "Gregory", "Dmitri", "Yelena", "Zhenya", "Zinaida", "Ivan", "Konstantin", "Leonid", "Mikhail", "Nikolai", "Olga", "Pavel", "Roman", "Semyon", "Tatyana", "Ulyana", "Fyodor", "Khariton", "Shura", "Yuri", "Yakov", "Anton", "Galina", "Yolka", "Zoya", "Mariya", "Sergei", "Tamara", "Emma"];
 
 // Misc variables
 markers_reset = [99999,99999,0];

--- a/Missionframework/stringtable.xml
+++ b/Missionframework/stringtable.xml
@@ -611,7 +611,7 @@
             <Japanese>FOB トラック</Japanese>
         </Key>
         <Key ID="STR_RESPAWN_TRUCK">
-            <Original>Mobile respawn</Original>
+            <Original>MSP</Original>
             <French>Respawn mobile</French>
             <German>Mobiler Respawn</German>
             <Spanish>Respawn móvil</Spanish>


### PR DESCRIPTION
Use "<russian military alphabet name> <series of random 3 digits>" for an MSP name. Assigned at the first read.